### PR TITLE
updated versions of libgcc-ng and libstdcxx-ng

### DIFF
--- a/paraCell_conda_R.yml
+++ b/paraCell_conda_R.yml
@@ -52,7 +52,7 @@ dependencies:
   - libedit=3.1.20191231
   - libev=4.33
   - libffi=3.3
-  - libgcc-ng=9.1.0
+  - libgcc-ng=11.2.0
   - libgfortran-ng=7.5.0
   - libgfortran4=7.5.0
   - libiconv=1.16
@@ -62,7 +62,7 @@ dependencies:
   - libpng=1.6.37
   - libsodium=1.0.18
   - libssh2=1.9.0
-  - libstdcxx-ng=9.1.0
+  - libstdcxx-ng=13.2.0
   - libtiff=4.1.0
   - libuuid=2.32.1
   - libuv=1.34.0


### PR DESCRIPTION
I created a Dockerfile for paraCell, but found that the conda environment kept failing to build within the Docker Container due to package dependency issues.
Specifically, some of the R dependencies required a higher version of the "libgcc-ng" and "libstdcxx-ng" than what was listed in paraCell_conda_R.yml. This was causing an error that prevented the Dockerfile from successfully creating a Docker Image.

When I investigated these packages in the functional paraCell conda environment I had created on my local machine, I found that they were of a higher version than what was specified in the YAML file.
The YAML file specifies "libgcc-ng=9.1.0" and "libstdcxx-ng=9.1.0".
The final functional environment contains "libgcc-ng=11.2.0"  and "libstdcxx-ng=13.2.0".

It seems that the local machine installation process is capable of dynamically updating the version of these packages to accommodate the R dependencies, but the Docker Container installation process cannot.

To fix this, I have edited paraCell_conda_R.yml to specify the newer/correct versions of these packages.
This fixes the Docker installation process, and does not disrupt the local installation process. 
